### PR TITLE
Fix retry logic and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# Debug
+# PDF Analyzer
+
+This repository contains a Streamlit application for analyzing PDF files using the OpenAI API with built‑in rate limiting and progress tracking.
+
+## Usage
+Install the required dependencies and run:
+
+```bash
+streamlit run pdf_analyzer.py
+```


### PR DESCRIPTION
## Summary
- clean up README
- adjust chunk retry logic to resume based on previous attempts
- track failed attempts immediately
- drop unused imports

## Testing
- `python3 -m py_compile pdf_analyzer.py`
- `flake8 pdf_analyzer.py` *(fails: E501 line too long, E302 expected 2 blank lines, W293 blank line contains whitespace)*

------
https://chatgpt.com/codex/tasks/task_b_68781756c818832b8d0e97b3a381ab44