### PR TITLE
Make model, tokens and temperature configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Analyzer
 
-This repository contains a Streamlit application for analyzing PDF files using the OpenAI API with built‑in rate limiting and progress tracking.
+This repository contains a Streamlit application for analyzing PDF files using the OpenAI API with built‑in rate limiting and progress tracking. The sidebar allows you to configure rate limiting as well as the OpenAI model, maximum tokens and temperature used for generation.
 
 ## Usage
 Install the required dependencies and run:


### PR DESCRIPTION
## Summary
- expose OpenAI model, max tokens and temperature in the sidebar
- pass these values to `RateLimitConfig`
- use them when calling the API
- document configurable model parameters in the README

## Testing
- `python -m py_compile pdf_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_b_68781aeedcec832b83cabcda36155432